### PR TITLE
Use two space indentation

### DIFF
--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -31,7 +31,7 @@
   "Major mode of Terraform configuration file."
   :group 'languages)
 
-(defcustom terraform-indent-level tab-width
+(defcustom terraform-indent-level 2
   "The tab width to use when indenting."
   :type 'integer
   :group 'terraform)


### PR DESCRIPTION
All examples in terraform's examples directory use two space
indentation.

https://github.com/hashicorp/terraform/pull/3129