### PR TITLE
Font lock improvements

### DIFF
--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -53,7 +53,7 @@
   "^\\s-+\\(provisioner\\)\\s-+\"")
 
 (defconst terraform--internal-block-regexp
-  "^\\s-+\\(connection\\|triggers\\|vars\\)\\s-+\{")
+  "^\\s-+\\([^\"\{]+\\)\\s-+\{")
 
 (defvar terraform-font-lock-keywords
   `((,terraform--block-regexp 1 font-lock-keyword-face)

--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -52,10 +52,14 @@
 (defconst terraform--provisioner-regexp
   "^\\s-+\\(provisioner\\)\\s-+\"")
 
+(defconst terraform--internal-block-regexp
+  "^\\s-+\\(connection\\|triggers\\|vars\\)\\s-+\{")
+
 (defvar terraform-font-lock-keywords
-  `((,terraform--block-regexp 1 font-lock-function-name-face)
-    (,terraform--atlas-regexp 1 font-lock-function-name-face)
-    (,terraform--provisioner-regexp 1 font-lock-function-name-face)
+  `((,terraform--block-regexp 1 font-lock-keyword-face)
+    (,terraform--atlas-regexp 1 font-lock-keyword-face)
+    (,terraform--provisioner-regexp 1 font-lock-keyword-face)
+    (,terraform--internal-block-regexp 1 font-lock-keyword-face)
     ,@hcl-font-lock-keywords))
 
 (defun terraform-format-buffer ()


### PR DESCRIPTION
use keyword face rather than function name.

Also matches internal blocks, such as the connection block.