### PR TITLE
make imenu-sort-function as local variable in terraform-mode

### DIFF
--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -354,8 +354,7 @@ If the point is not at the heading, call
   (terraform--setup-outline-mode)
 
   ;; imenu
-  (make-local-variable 'imenu-sort-function)
-  (setq imenu-sort-function 'imenu--sort-by-name)
+  (set (make-local-variable 'imenu-sort-function) 'imenu--sort-by-name)
   (setq imenu-create-index-function 'terraform--generate-imenu)
   (imenu-add-to-menubar "Terraform"))
 

--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -354,6 +354,7 @@ If the point is not at the heading, call
   (terraform--setup-outline-mode)
 
   ;; imenu
+  (make-local-variable 'imenu-sort-function)
   (setq imenu-sort-function 'imenu--sort-by-name)
   (setq imenu-create-index-function 'terraform--generate-imenu)
   (imenu-add-to-menubar "Terraform"))


### PR DESCRIPTION
Since `imenu-sort-function` is not a buffer-local variable, we need to explicitly make it local.