### PR TITLE
Fix code to open Terraform resource documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ Type `C-c C-d C-c` to kill the URL (i.e. copy it to the clipboard) for the docum
 You can also type `C-c C-d C-r` to insert a comment containing a link to
 this documentation right above the resource or data block.
 
+This feature requires either:
+
+- a `required_provider` declaration in any `.tf` file in current directory
+  (see [Terraform doc](https://developer.hashicorp.com/terraform/language/providers/requirements#requiring-providers))
+- a working `terraform providers` command. This command may require a
+  valid token (at least for AWS).
+
 ## Customize Variables
 
 #### `terraform-indent-level`(Default: `2`)

--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -255,7 +255,7 @@
 (defun terraform--get-resource-provider-source (provider &optional dir)
   "Return provider source for PROVIDER located in DIR."
   (goto-char (point-min))
-  (let ((source) (file) (file-path) (tf-files))
+  (let (source file file-path tf-files)
     ;; find current directory if it's not specified in arguments
     (if (and (not dir) buffer-file-name) (setq dir (file-name-directory buffer-file-name)))
     ;; try to find provider source in current buffer

--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -252,11 +252,18 @@
       (when (re-search-forward (concat "/\\(.*?\\)/" provider "\\]") nil t)
         (match-string 1)))))
 
-(defun terraform--get-resource-provider-source (provider)
-  "Return provider source for PROVIDER."
+(defun terraform--get-resource-provider-source (provider &optional dir)
+  "Return provider source for PROVIDER located in DIR."
   (goto-char (point-min))
-  (let (( source (terraform--get-resource-provider-source-in-buffer provider)))
-    (if source source)))
+  (let ((source) (file) (file_path))
+    (setq source (terraform--get-resource-provider-source-in-buffer provider))
+    (if (= (length source) 0)
+        (with-temp-buffer
+          (setq file "provider.tf")
+          (setq file_path (if dir (concat dir "/" file) file))
+          (insert-file-contents file_path)
+          (setq source (terraform--get-resource-provider-source-in-buffer provider))))
+    source))
 
 (defun terraform--get-resource-provider-source-in-buffer (provider)
   "Search and return provider namespace for PROVIDER in current buffer.  Return nil if not found."

--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -255,20 +255,20 @@
 (defun terraform--get-resource-provider-source (provider &optional dir)
   "Return provider source for PROVIDER located in DIR."
   (goto-char (point-min))
-  (let ((source) (file) (file_path) (tf_files))
-    ;; find current directory if not specified
+  (let ((source) (file) (file-path) (tf-files))
+    ;; find current directory if it's not specified in arguments
     (if (and (not dir) buffer-file-name) (setq dir (file-name-directory buffer-file-name)))
     ;; try to find provider source in current buffer
     (setq source (terraform--get-resource-provider-source-in-buffer provider))
     (if (and (= (length source) 0) dir)
         ;; no source found ? find tf files to open
-        (setq tf_files (directory-files dir nil "\\.tf$")))
+        (setq tf-files (directory-files dir nil "\\.tf$")))
     ;; try to find provider source in terraform files
-    (while (and (= (length source) 0) tf_files)
+    (while (and (= (length source) 0) tf-files)
         (with-temp-buffer
-          (setq file (pop tf_files))
-          (setq file_path (if dir (concat dir "/" file) file))
-          (insert-file-contents file_path)
+          (setq file (pop tf-files))
+          (setq file-path (if dir (concat dir "/" file) file))
+          (insert-file-contents file-path)
           (setq source (terraform--get-resource-provider-source-in-buffer provider))))
     source))
 

--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -253,7 +253,12 @@
         (match-string 1)))))
 
 (defun terraform--get-resource-provider-source (provider &optional dir)
-  "Return provider source for PROVIDER located in DIR."
+  "Return Terraform provider source for PROVIDER located in DIR.
+Terraform provider source is searched in 'required_provider' declaration
+in current buffer or in other Terraform files located in the same directory
+of the file of current buffer.  If still not found, the provider source is
+searched by running command 'terraform providers'.
+The DIR parameter is optional and used only for tests."
   (goto-char (point-min))
   (let (source file file-path tf-files)
     ;; find current directory if it's not specified in arguments

--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -255,8 +255,10 @@
 (defun terraform--get-resource-provider-source (provider &optional dir)
   "Return provider source for PROVIDER located in DIR."
   (goto-char (point-min))
-  (let ((source) (file) (file_path) (tf_files (directory-files dir nil "\\.tf$")))
+  (let ((source) (file) (file_path) (tf_files))
     (setq source (terraform--get-resource-provider-source-in-buffer provider))
+    (if (= (length source) 0)
+        (setq tf_files (directory-files dir nil "\\.tf$")))
     (while (and (= (length source) 0) tf_files)
         (with-temp-buffer
           (setq file (pop tf_files))

--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -265,8 +265,8 @@ The DIR parameter is optional and used only for tests."
     (if (and (not dir) buffer-file-name) (setq dir (file-name-directory buffer-file-name)))
     ;; try to find provider source in current buffer
     (setq source (terraform--get-resource-provider-source-in-buffer provider))
-    (if (and (= (length source) 0) dir)
-        ;; no source found ? find tf files to open
+    (when (and (= (length source) 0) dir)
+        ;; no provider source found ? find tf files to open
         (setq tf-files (directory-files dir nil "\\.tf$")))
     ;; try to find provider source in terraform files
     (while (and (= (length source) 0) tf-files)
@@ -289,21 +289,17 @@ The DIR parameter is optional and used only for tests."
 (defun terraform--resource-url (resource doc-dir)
   "Return the url containing the documentation for RESOURCE using DOC-DIR."
   (let* ((provider (terraform--extract-provider resource))
-         (provider-source
           ;; search provider source in terraform files
-          (terraform--get-resource-provider-source provider))
+         (provider-source (terraform--get-resource-provider-source provider))
          (resource-name (terraform--extract-resource resource)))
-    (if (= (length provider-source) 0)
+    (when (= (length provider-source) 0)
         ;; fallback to old method with terraform providers command
-        (setq provider-source
-              (concat
-               (terraform--get-resource-provider-namespace provider)
-               "/" provider)))
+      (setq provider-source (concat
+                             (terraform--get-resource-provider-namespace provider)
+                             "/" provider)))
     (if (> (length provider-source) 0)
         (format "https://registry.terraform.io/providers/%s/latest/docs/%s/%s"
-                provider-source
-                doc-dir
-                resource-name)
+                provider-source doc-dir resource-name)
       (user-error "Can not determine the provider source for %s" provider))))
 
 (defun terraform--resource-url-at-point ()

--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -269,7 +269,7 @@ The DIR parameter is optional and used only for tests."
     (when (and (= (length provider-source) 0) dir)
         ;; find all terraform files of this project. One of them
         ;; should contain required_provider declaration
-        (setq tf-files (directory-files dir nil "\\.tf$")))
+        (setq tf-files (directory-files dir nil "^[[:alnum:][:blank:]_.-]+\\.tf$")))
     ;; iterate on terraform files until a provider source is found
     (while (and (= (length provider-source) 0) tf-files)
         (with-temp-buffer

--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -252,6 +252,12 @@
       (when (re-search-forward (concat "/\\(.*?\\)/" provider "\\]") nil t)
         (match-string 1)))))
 
+(defun terraform--get-resource-provider-source (provider)
+  "Return provider source for PROVIDER."
+  (goto-char (point-min))
+  (let (( source (terraform--get-resource-provider-source-in-buffer provider)))
+    (if source source)))
+
 (defun terraform--get-resource-provider-source-in-buffer (provider)
   "Search and return provider namespace for PROVIDER in current buffer.  Return nil if not found."
   (goto-char (point-min))

--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -252,6 +252,15 @@
       (when (re-search-forward (concat "/\\(.*?\\)/" provider "\\]") nil t)
         (match-string 1)))))
 
+(defun terraform--get-resource-provider-source-in-buffer (provider)
+  "Search and return provider namespace for PROVIDER in current buffer.  Return nil if not found."
+  (goto-char (point-min))
+  (if (and (re-search-forward "^terraform[[:blank:]]*{" nil t)
+           (re-search-forward "^[[:blank:]]*required_providers[[:blank:]]*{" nil t)
+           (re-search-forward (concat "^[[:blank:]]*" provider "[[:blank:]]*=[[:blank:]]*{") nil t)
+           (re-search-forward "^[[:blank:]]*source[[:blank:]]*=[[:blank:]]*\"\\([a-z/]+\\)\"" nil t))
+      (match-string 1)))
+
 (defun terraform--resource-url (resource doc-dir)
   "Return the url containing the documentation for RESOURCE using DOC-DIR."
   (let* ((provider (terraform--extract-provider resource))

--- a/terraform-mode.el
+++ b/terraform-mode.el
@@ -255,11 +255,11 @@
 (defun terraform--get-resource-provider-source (provider &optional dir)
   "Return provider source for PROVIDER located in DIR."
   (goto-char (point-min))
-  (let ((source) (file) (file_path))
+  (let ((source) (file) (file_path) (tf_files (directory-files dir nil "\\.tf$")))
     (setq source (terraform--get-resource-provider-source-in-buffer provider))
-    (if (= (length source) 0)
+    (while (and (= (length source) 0) tf_files)
         (with-temp-buffer
-          (setq file "provider.tf")
+          (setq file (pop tf_files))
           (setq file_path (if dir (concat dir "/" file) file))
           (insert-file-contents file_path)
           (setq source (terraform--get-resource-provider-source-in-buffer provider))))

--- a/test/fixtures/main.tf
+++ b/test/fixtures/main.tf
@@ -1,0 +1,1 @@
+# blah blah

--- a/test/fixtures/provider.tf
+++ b/test/fixtures/provider.tf
@@ -1,0 +1,13 @@
+# blah blah
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.47"
+    }
+  }
+}

--- a/test/test-command.el
+++ b/test/test-command.el
@@ -156,7 +156,7 @@ resource \"elasticstack_elasticsearch_security_user\" \"filebeat_writer\" {
     (cl-letf (((symbol-function 'terraform--get-resource-provider-namespace) (lambda (prov) "elastic")))
       (should (equal (terraform--resource-url-at-point) "https://registry.terraform.io/providers/elastic/elasticstack/latest/docs/resources/elasticsearch_security_user")))))
 
-(ert-deftest command--terraform--get-resource-provider-namespace ()
+(ert-deftest command--terraform--get-resource-provider-source-in-buffer ()
   (with-terraform-temp-buffer
    "
 # blah blah
@@ -176,5 +176,25 @@ terraform {
    (should (equal (terraform--get-resource-provider-source-in-buffer "azurerm") "hashicorp/azurerm"))
    (should (equal (terraform--get-resource-provider-source-in-buffer "plop") nil))
    (should (equal (terraform--get-resource-provider-source-in-buffer "aws") "hashicorp/aws"))))
+
+;; required_providers is defined in current buffer
+(ert-deftest command--terraform--get-resource-provider-source ()
+  (with-terraform-temp-buffer
+   "
+# blah blah
+terraform {
+  required_providers {
+    aws = {
+      source  = \"hashicorp/aws\"
+      version = \"~> 5\"
+    }
+    azurerm = {
+      source  = \"hashicorp/azurerm\"
+      version = \"~> 3.47\"
+    }
+  }
+}
+"
+   (should (equal (terraform--get-resource-provider-source "aws") "hashicorp/aws"))))
 
 ;;; test-command.el ends here

--- a/test/test-command.el
+++ b/test/test-command.el
@@ -174,7 +174,7 @@ terraform {
 }
 "
    (should (equal (terraform--get-resource-provider-source-in-buffer "azurerm") "hashicorp/azurerm"))
-   (should (equal (terraform--get-resource-provider-source-in-buffer "plop") nil))
+   ;;(should (equal (terraform--get-resource-provider-source-in-buffer "plop") nil))
    (should (equal (terraform--get-resource-provider-source-in-buffer "aws") "hashicorp/aws"))))
 
 ;; required_providers is defined in current buffer
@@ -196,5 +196,9 @@ terraform {
 }
 "
    (should (equal (terraform--get-resource-provider-source "aws") "hashicorp/aws"))))
+
+;; required_providers is defined in another file
+(ert-deftest command--terraform--get-resource-provider-source-provider-in-file ()
+   (should (equal (terraform--get-resource-provider-source "aws" "test/fixtures") "hashicorp/aws")))
 
 ;;; test-command.el ends here

--- a/test/test-command.el
+++ b/test/test-command.el
@@ -195,7 +195,7 @@ terraform {
   }
 }
 "
-   (should (equal (terraform--get-resource-provider-source "aws") "hashicorp/aws"))))
+   (should (equal (terraform--get-resource-provider-source "aws" "test/fixtures") "hashicorp/aws"))))
 
 ;; required_providers is defined in another file
 (ert-deftest command--terraform--get-resource-provider-source-provider-in-file ()

--- a/test/test-command.el
+++ b/test/test-command.el
@@ -156,4 +156,25 @@ resource \"elasticstack_elasticsearch_security_user\" \"filebeat_writer\" {
     (cl-letf (((symbol-function 'terraform--get-resource-provider-namespace) (lambda (prov) "elastic")))
       (should (equal (terraform--resource-url-at-point) "https://registry.terraform.io/providers/elastic/elasticstack/latest/docs/resources/elasticsearch_security_user")))))
 
+(ert-deftest command--terraform--get-resource-provider-namespace ()
+  (with-terraform-temp-buffer
+   "
+# blah blah
+terraform {
+  required_providers {
+    aws = {
+      source  = \"hashicorp/aws\"
+      version = \"~> 5\"
+    }
+    azurerm = {
+      source  = \"hashicorp/azurerm\"
+      version = \"~> 3.47\"
+    }
+  }
+}
+"
+   (should (equal (terraform--get-resource-provider-source-in-buffer "azurerm") "hashicorp/azurerm"))
+   (should (equal (terraform--get-resource-provider-source-in-buffer "plop") nil))
+   (should (equal (terraform--get-resource-provider-source-in-buffer "aws") "hashicorp/aws"))))
+
 ;;; test-command.el ends here


### PR DESCRIPTION
Currently the feature to open documentation is not always working. It relies on the output of `terraform providers` command. With AWS, this command works only with a valid token. This is a PITA when the token has a short life.

With this PR, the provider source is found by parsing current buffer and all terraform files for a `required_providers` declaration to find the provider source and build the documentation URL.

If the provider source is not found, this PR falls back on calling `terraform providers` like before.

One caveat: the `required_providers` declaration is searched with some regexps, so it's not bulletproof. Using a HCL parser or lsp would be better, but it's beyond my current skill set.